### PR TITLE
Fix linked URL in credits

### DIFF
--- a/MacDependency/English.lproj/Credits.rtf
+++ b/MacDependency/English.lproj/Credits.rtf
@@ -11,5 +11,5 @@
 
 \b Website\
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural\partightenfactor0
-\cf0 	{\field{\*\fldinst{HYPERLINK "http://macdependency.googlecode.com"}}{\fldrslt 
+\cf0 	{\field{\*\fldinst{HYPERLINK "https://github.com/kwin/macdependency"}}{\fldrslt 
 \b0 https://github.com/kwin/macdependency}}}


### PR DESCRIPTION
Clicking the link on the about page sent me to Google Code 😅 